### PR TITLE
Add basic M3U8 playlist file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ git_branch = $(shell git rev-parse --abbrev-ref HEAD)
 git_hash = $(shell git rev-parse --short HEAD)
 
 zip_name = $(name)-$(version)-$(git_branch)-$(git_hash).zip
-include_files = addon.xml LICENSE README.md resources/
+include_files = addon.xml LICENSE README.md regiotv.m3u8 resources/
 include_paths = $(patsubst %,$(name)/%,$(include_files))
 exclude_files = \*.new \*.orig \*.pyc \*.pyo
 zip_dir = $(name)/

--- a/regiotv.m3u8
+++ b/regiotv.m3u8
@@ -1,0 +1,21 @@
+#EXTM3U
+#EXTINF:-1 tvg-id="atv" tvg-logo="http://static.atv.be/atvbe/meta/android-chrome-192x192.png" tvg-name="ATV (Antwerpen)",ATV (Antwerpen)
+http://api.new.livestream.com/accounts/27755193/events/8452381/live.m3u8
+
+#EXTINF:-1 tvg-id="bruzz" tvg-logo="https://i.imgur.com/rcfUiWV.jpg" tvg-name="BRUZZ (Brussel)",BRUZZ (Brussel)
+https://hls-origin01-bruzz.cdn02.rambla.be/main/adliveorigin-bruzz/_definst_/V3n5YY.smil/chunklist.m3u8
+
+#EXTINF:-1 tvg-id="focustv" tvg-logo="https://i.imgur.com/aGORIN8.png" tvg-name="Focus TV (West-Vlaanderen)",Focus TV (West-Vlaanderen)
+https://hls-origin01-focus-wtv.cdn01.rambla.be/main/adliveorigin-focus-wtv/_definst_/ARXpX7.smil/playlist.m3u8
+
+#EXTINF:-1 tvg-id="robtv" tvg-logo="http://static.tvl.be/robtvbe/meta/android-chrome-192x192.png" tvg-name="ROB-tv (Oost-Brabant)",ROB-tv (Oost-Brabant)
+http://api.new.livestream.com/accounts/27755193/events/8462344/live.m3u8
+
+#EXTINF:-1 tvg-id="tvl" tvg-logo="http://static.tvl.be/tvlbe/meta/android-chrome-192x192.png" tvg-name="TVL (Limburg)",TVL (Limburg)
+http://api.new.livestream.com/accounts/27755193/events/8452383/live.m3u8
+
+#EXTINF:-1 tvg-id="tvoost" tvg-logo="http://static.tvoost.be/tvoostbe/meta/android-chrome-192x192.png" tvg-name="TV Oost (Oost-Vlaanderen)",TV Oost (Oost-Vlaanderen)
+http://api.new.livestream.com/accounts/27755193/events/8511193/live.m3u8
+
+#EXTINF:-1 tvg-id="wtv" tvg-logo="https://i.imgur.com/aGORIN8.png" tvg-name="WTV (West-Vlaanderen)",WTV (West-Vlaanderen)
+https://hls-origin01-focus-wtv.cdn01.rambla.be/main/adliveorigin-focus-wtv/_definst_/AG1G1l.smil/playlist.m3u8


### PR DESCRIPTION
This is basic support for PVR IPTV Simple support in Kodi. It is a poor
man's implementation that (as it is) only adds RegioTV support to Kodi.

A better alternative is to use IPTV Manager in the future, nevertheless
this may be useful to some already as-is.