### PR TITLE
This fixes an exception raised on Matrix

### DIFF
--- a/resources/lib/iptvmanager.py
+++ b/resources/lib/iptvmanager.py
@@ -24,7 +24,7 @@ class IPTVManager(object):
             sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             sock.connect(('127.0.0.1', self.port))
             try:
-                sock.sendall(json.dumps(func()))  # pylint: disable=not-callable
+                sock.sendall(json.dumps(func()).encode())  # pylint: disable=not-callable
             finally:
                 sock.close()
 


### PR DESCRIPTION
When IPTV Manager synchronizes the channel list or EPG data an exception
is raised on Matrix. This fixes it.